### PR TITLE
Fix nav links and simplify XP layout

### DIFF
--- a/services/website/app/components/BlogCard.tsx
+++ b/services/website/app/components/BlogCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import NextImage from 'next/image';
-import { Link } from '@heroui/link';
 import { ArrowUpRight } from 'lucide-react';
+import { siteUrl } from '../data/site';
 
 export type BlogCardProps = {
   title: string;
@@ -39,8 +39,8 @@ export function BlogCard({
   const formattedDate = date ? formatDate(date) : undefined;
 
   return (
-    <Link
-      href={href}
+    <a
+      href={siteUrl(href)}
       className="
         group block rounded-xl overflow-hidden
         bg-[var(--color-background)]
@@ -96,6 +96,6 @@ export function BlogCard({
           </p>
         )}
       </div>
-    </Link>
+    </a>
   );
 }

--- a/services/website/app/components/BlogRenderer.tsx
+++ b/services/website/app/components/BlogRenderer.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { ComponentProps, ReactNode } from 'react';
-import { Link } from '@heroui/link';
 import NextImage from 'next/image';
 import { SiteBreadcrumbs } from './SiteBreadcrumbs';
 import { Button, Snippet, Card } from '@heroui/react';
+import { siteUrl } from '../data/site';
 
 // 1) Shape of the post metadata you consume:
 interface PostMeta {
@@ -41,11 +41,11 @@ export function BlogRenderer({ post, MDXBody }: BlogRendererProps) {
       <SiteBreadcrumbs items={crumbs} />
 
       <div className="mb-6">
-        <Link href="/blog">
+        <a href={siteUrl('/blog')}>
           <Button as="span" variant="flat" size="sm">
             ← All Writing
           </Button>
-        </Link>
+        </a>
       </div>
 
       <h1 className="text-4xl font-bold">{post.title}</h1>
@@ -115,9 +115,9 @@ export function BlogRenderer({ post, MDXBody }: BlogRendererProps) {
 
             // turn MDX <a> into HeroUI Link
             a: ({ href = '#', children }: { href?: string; children: ReactNode }) => (
-              <Link href={href} className="underline">
+              <a href={href.startsWith('http') ? href : siteUrl(href)} className="underline">
                 {children}
-              </Link>
+              </a>
             ),
 
             // turn MDX <Image> into NextImage
@@ -146,11 +146,11 @@ export function BlogRenderer({ post, MDXBody }: BlogRendererProps) {
         />
 
         <div className="mt-6">
-          <Link href="/blog">
+          <a href={siteUrl('/blog')}>
             <Button as="span" variant="flat" size="md">
               ← All Writing
             </Button>
-          </Link>
+          </a>
         </div>
       </article>
     </main>

--- a/services/website/app/components/Footer.tsx
+++ b/services/website/app/components/Footer.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link';
 import Image from 'next/image';
 import { Github, Linkedin, ExternalLink } from 'lucide-react';
 import { Button } from '@heroui/react';
 import { siteTechStack } from '../data/profile';
 import { TechIconRow } from './TechIconRow';
+import { siteUrl } from '../data/site';
 
 const socialLinks = [
   {
@@ -33,7 +33,7 @@ export function Footer() {
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-12 gap-8 md:gap-12">
           {/* Brand Column */}
           <div className="sm:col-span-2 md:col-span-5 space-y-6">
-            <Link href="/" className="inline-flex items-center gap-3 group">
+            <a href={siteUrl('/')} className="inline-flex items-center gap-3 group">
               <div className="relative w-10 h-10 rounded-full overflow-hidden ring-1 ring-[var(--color-border)]">
                 <Image
                   src="/images/avatar.jpg"
@@ -46,7 +46,7 @@ export function Footer() {
               <span className="font-semibold text-[var(--color-foreground)] group-hover:text-[var(--color-accent)] transition-colors">
                 Craig Watt
               </span>
-            </Link>
+            </a>
             <p className="text-sm text-[var(--color-muted-foreground)] max-w-xs leading-relaxed">
               Platform Engineer focused on observability, automation, and reliable delivery.
             </p>
@@ -67,19 +67,19 @@ export function Footer() {
             <ul className="space-y-3">
               {navLinks.map((link) => (
                 <li key={link.label}>
-                  <Link 
-                    href={link.href}
+                  <a
+                    href={siteUrl(link.href)}
                     className="text-sm text-[var(--color-muted-foreground)] hover:text-[var(--color-accent)] transition-colors"
                   >
                     {link.label}
-                  </Link>
+                  </a>
                 </li>
               ))}
             </ul>
             <div className="mt-6">
               <Button
-                as={Link}
-                href="/cv"
+                as="a"
+                href={siteUrl('/cv')}
                 variant="flat"
                 className="border border-[var(--color-border)] bg-[var(--color-card)] text-[var(--color-foreground)] hover:bg-[var(--color-background)]"
               >

--- a/services/website/app/components/Navbar.tsx
+++ b/services/website/app/components/Navbar.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import NextLink from 'next/link';
 import Image from 'next/image';
 import {
   Navbar as HeroNavbar,
@@ -18,6 +17,7 @@ import { ChevronDown } from './icons';
 import { navItems } from '../config/nav.config';
 import { NavbarRightIcons, externalTools } from './NavbarRightIcons';
 import { ThemeSwitcher } from './ThemeSwitcher';
+import { siteUrl } from '../data/site';
 
 export const Navbar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -51,8 +51,8 @@ export const Navbar = () => {
         {/* Center: Brand */}
         <NavbarBrand className="flex-1 flex justify-center">
           <NavbarItem>
-            <NextLink
-              href="/"
+            <a
+              href={siteUrl('/')}
               onClick={() => setIsMenuOpen(false)}
               className="group flex items-center space-x-2 p-0"
             >
@@ -75,7 +75,7 @@ export const Navbar = () => {
               <span className="font-bold text-base text-[var(--color-foreground)] transition-opacity group-hover:opacity-80">
                 Craig Watt
               </span>
-            </NextLink>
+            </a>
           </NavbarItem>
         </NavbarBrand>
         {/* Right: theme switcher */}
@@ -88,8 +88,8 @@ export const Navbar = () => {
       <NavbarContent className="hidden sm:flex items-center">
         <NavbarBrand>
           <NavbarItem>
-            <NextLink
-              href="/"
+            <a
+              href={siteUrl('/')}
               className="group flex items-center space-x-2 p-0"
             >
               <div
@@ -111,7 +111,7 @@ export const Navbar = () => {
               <span className="font-bold text-base text-[var(--color-foreground)] transition-opacity group-hover:opacity-80">
                 Craig Watt
               </span>
-            </NextLink>
+            </a>
           </NavbarItem>
         </NavbarBrand>
       </NavbarContent>
@@ -123,8 +123,8 @@ export const Navbar = () => {
             return (
               <NavbarItem key={item.label}>
                 <Button
-                  as={NextLink}
-                  href={item.href}
+                  as="a"
+                  href={siteUrl(item.href)}
                   variant="light"
                   className={`
                     px-4 py-2 ${itemRounded}
@@ -138,20 +138,17 @@ export const Navbar = () => {
             );
           }
 
-          const isExternal = item.href.startsWith('http');
           return (
             <NavbarItem key={item.label}>
               <Button
-                as={isExternal ? "a" : NextLink}
-                href={item.href}
+                as="a"
+                href={siteUrl(item.href)}
                 variant="light"
                 className={`
               px-4 py-2 ${itemRounded}
               text-base !text-[var(--color-foreground)]
               ${hoverBgClass}
               `}
-                target={isExternal ? '_blank' : undefined}
-                rel={isExternal ? 'noopener noreferrer' : undefined}
                 onPress={() => setIsMenuOpen(false)}
               >
                 {item.label}
@@ -169,11 +166,10 @@ export const Navbar = () => {
         {/* 1) Projects (top-level links without children) */}
         {navItems.map((item) => {
           if (!Array.isArray(item.children)) {
-            const isExternal = item.href.startsWith('http');
             return (
               <NavbarMenuItem key={item.label}>
-                <NextLink
-                  href={item.href}
+                <a
+                  href={siteUrl(item.href)}
                   onClick={() => setIsMenuOpen(false)}
                   className={`
                     w-full flex items-center
@@ -181,11 +177,9 @@ export const Navbar = () => {
                     text-foreground text-base
                     ${hoverBgClass}
                   `}
-                  target={isExternal ? '_blank' : undefined}
-                  rel={isExternal ? 'noopener noreferrer' : undefined}
                 >
                   {item.label}
-                </NextLink>
+                </a>
               </NavbarMenuItem>
             );
           }
@@ -200,7 +194,7 @@ export const Navbar = () => {
                 <NavbarMenuItem>
                   <button
                     type="button"
-                    onClick={() => setMobileBlogOpen((prev) => !prev)}
+                      onClick={() => setMobileBlogOpen((prev) => !prev)}
                     className={`
                       w-full flex items-center justify-between
                       ${mobileItemPadding} ${itemRounded}
@@ -218,14 +212,14 @@ export const Navbar = () => {
                     />
                   </button>
                 </NavbarMenuItem>
-                {mobileBlogOpen &&
+                    {mobileBlogOpen &&
                   item.children.map((child) => {
                     const childExternal = child.href.startsWith('http');
                     const isCurrent = false; // optionally detect current route
                     return (
                       <NavbarMenuItem key={child.label}>
-                        <NextLink
-                          href={child.href}
+                        <a
+                          href={childExternal ? child.href : siteUrl(child.href)}
                           onClick={() => setIsMenuOpen(false)}
                           className={`
                             w-full flex items-center gap-2
@@ -238,15 +232,11 @@ export const Navbar = () => {
                             }
                             text-foreground text-base
                           `}
-                          target={childExternal ? '_blank' : undefined}
-                          rel={
-                            childExternal ? 'noopener noreferrer' : undefined
-                          }
                           aria-current={isCurrent ? 'page' : undefined}
                         >
                           <span className="flex-shrink-0">{child.icon}</span>
                           <span>{child.label}</span>
-                        </NextLink>
+                        </a>
                       </NavbarMenuItem>
                     );
                   })}
@@ -266,9 +256,9 @@ export const Navbar = () => {
                 : 'bg-white dark:bg-slate-200';
               
               return (
-                <NextLink
+                <a
                   key={tool.alt}
-                  href={tool.href}
+                  href={tool.internal ? siteUrl(tool.href) : tool.href}
                   target={tool.internal ? undefined : '_blank'}
                   rel={tool.internal ? undefined : 'noopener noreferrer'}
                   onClick={() => setIsMenuOpen(false)}
@@ -308,7 +298,7 @@ export const Navbar = () => {
                       priority={false}
                     />
                   ) : null}
-                </NextLink>
+                </a>
               );
             })}
           </div>

--- a/services/website/app/components/NavbarRightIcons.tsx
+++ b/services/website/app/components/NavbarRightIcons.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React from 'react';
-import NextLink from 'next/link';
 import Image from 'next/image';
 import {
   NavbarContent,
@@ -8,6 +7,7 @@ import {
   Button,
 } from '@heroui/react';
 import { ThemeSwitcher } from './ThemeSwitcher';
+import { siteUrl } from '../data/site';
 
 type ExternalTool = {
   href: string;
@@ -89,8 +89,8 @@ export function NavbarRightIcons() {
           return (
             <NavbarItem key={tool.alt}>
               <Button
-                as={NextLink}
-                href={tool.href}
+                as="a"
+                href={siteUrl(tool.href)}
                 variant="flat"
                 isIconOnly
                 className={`h-10 w-10 min-w-10 p-0 rounded-medium ${bgClass} border border-[var(--color-border)] hover:opacity-80`}

--- a/services/website/app/components/ProjectCard.tsx
+++ b/services/website/app/components/ProjectCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import NextImage from 'next/image';
-import { Link } from '@heroui/link';
 import { ArrowUpRight } from 'lucide-react';
+import { siteUrl } from '../data/site';
 
 export type ProjectCardProps = {
   title: string;
@@ -24,8 +24,8 @@ export function ProjectCard({
   badges = [],
 }: ProjectCardProps) {
   return (
-    <Link
-      href={href}
+    <a
+      href={siteUrl(href)}
       className="
         group block rounded-xl overflow-hidden
         bg-[var(--color-background)] 
@@ -82,6 +82,6 @@ export function ProjectCard({
           </div>
         )}
       </div>
-    </Link>
+    </a>
   );
 }

--- a/services/website/app/components/ProjectRenderer.tsx
+++ b/services/website/app/components/ProjectRenderer.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ComponentProps, ReactNode } from 'react';
-import { Link } from '@heroui/link';
 import NextImage from 'next/image';
 import { Snippet, Button, Card } from '@heroui/react';
 import { SiteBreadcrumbs } from './SiteBreadcrumbs';
 import { type Project } from 'content-collections';
+import { siteUrl } from '../data/site';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // MDXBody needs to accept arbitrary props (className, style, data-*, etc.)
@@ -35,11 +35,11 @@ export function ProjectRenderer({
 
       <article className="space-y-8">
         <div className="mb-6">
-          <Link href="/projects">
+          <a href={siteUrl('/projects')}>
             <Button as="span" variant="flat" size="sm">
               ← All Projects
             </Button>
-          </Link>
+          </a>
         </div>
 
         <h1 className="text-4xl font-bold">{project.title}</h1>
@@ -102,10 +102,10 @@ export function ProjectRenderer({
               li: (props: ComponentProps<'li'>) => (
                 <li className="text-lg leading-relaxed" {...props} />
               ),
-              a: ({ href = '#', children }: { href?: string; children: ReactNode }) => (
-                <Link href={href} className="underline">
+            a: ({ href = '#', children }: { href?: string; children: ReactNode }) => (
+                <a href={href.startsWith('http') ? href : siteUrl(href)} className="underline">
                   {children}
-                </Link>
+                </a>
               ),
 
               Snippet,
@@ -165,11 +165,11 @@ export function ProjectRenderer({
 
         {/* bottom links */}
         <div className="flex justify-between items-center mt-8">
-          <Link href="/projects">
+          <a href={siteUrl('/projects')}>
             <Button as="span" variant="flat" size="md">
               ← All Projects
             </Button>
-          </Link>
+          </a>
           {project.github && (
             <Button as="a" href={project.github} variant="ghost" size="md">
               View on GitHub

--- a/services/website/app/components/SiteBreadcrumbs.tsx
+++ b/services/website/app/components/SiteBreadcrumbs.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { Breadcrumbs, BreadcrumbItem } from '@heroui/react';
+import { siteUrl } from '../data/site';
 
 export type Crumb = {
   label: string;
@@ -15,7 +16,7 @@ export function SiteBreadcrumbs({ items }: { items: Crumb[] }) {
       {items.map((crumb, idx) => (
         <BreadcrumbItem
           key={idx}
-          {...(crumb.href && !crumb.current ? { href: crumb.href } : {})}
+          {...(crumb.href && !crumb.current ? { href: crumb.href.startsWith('http') ? crumb.href : siteUrl(crumb.href) } : {})}
           isCurrent={crumb.current}
         >
           {/* Just render text; BreadcrumbItem will wrap in <a> if href provided */}

--- a/services/website/app/credentials/page.tsx
+++ b/services/website/app/credentials/page.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
 import { Button, Card } from '@heroui/react';
 import { Award, ArrowRight } from 'lucide-react';
+import { siteUrl } from '../data/site';
 
 export default function CredentialsPage() {
   return (
@@ -30,17 +30,17 @@ export default function CredentialsPage() {
         </Card>
 
         <div className="flex justify-center gap-3">
-          <Link href="/experience">
+          <a href={siteUrl('/experience')}>
             <Button as="span" className="bg-[var(--color-accent)] text-[var(--color-accent-foreground)]">
               View Experience
               <ArrowRight className="h-4 w-4 ml-2" />
             </Button>
-          </Link>
-          <Link href="/cv">
+          </a>
+          <a href={siteUrl('/cv')}>
             <Button as="span" variant="flat" className="border border-[var(--color-border)]">
               Open CV
             </Button>
-          </Link>
+          </a>
         </div>
       </div>
     </main>

--- a/services/website/app/cv/page.tsx
+++ b/services/website/app/cv/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import Link from 'next/link';
 import { Button, Card } from '@heroui/react';
 import { Download, FileText, Printer, ShieldCheck } from 'lucide-react';
 import { coreSkills, experienceTimeline, profilePositioning } from '../data/profile';
 import { TechIconRow } from '../components/TechIconRow';
+import { siteUrl } from '../data/site';
 
 export default function CvPage() {
   const printPage = () => window.print();
@@ -51,16 +51,16 @@ export default function CvPage() {
           >
             Save as PDF
           </Button>
-          <Link href="/experience">
+          <a href={siteUrl('/experience')}>
             <Button as="span" variant="flat" startContent={<FileText className="h-4 w-4" />}>
               Experience
             </Button>
-          </Link>
-          <Link href="/credentials">
+          </a>
+          <a href={siteUrl('/credentials')}>
             <Button as="span" variant="flat" startContent={<ShieldCheck className="h-4 w-4" />}>
               Credentials
             </Button>
-          </Link>
+          </a>
         </div>
       </div>
 

--- a/services/website/app/data/site.ts
+++ b/services/website/app/data/site.ts
@@ -1,0 +1,5 @@
+export const siteOrigin = 'https://www.craigwatt.co.uk';
+
+export function siteUrl(path: string) {
+  return new URL(path, siteOrigin).toString();
+}

--- a/services/website/app/experience/page.tsx
+++ b/services/website/app/experience/page.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { useEffect, useMemo, useState, useRef } from 'react';
-import Link from 'next/link';
-import { Button, Card } from '@heroui/react';
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@heroui/react';
 import { ArrowRight } from 'lucide-react';
-import { experienceTimeline, profilePositioning } from '../data/profile';
+import { experienceTimeline } from '../data/profile';
 import { TechIconRow } from '../components/TechIconRow';
+import { siteUrl } from '../data/site';
 
 export default function ExperiencePage() {
   const [activeId, setActiveId] = useState(experienceTimeline[0]?.id ?? '');
   const [isScrolled, setIsScrolled] = useState(false);
-  const lastScrollY = useRef(0);
 
   const activeIndex = useMemo(
     () => experienceTimeline.findIndex((item) => item.id === activeId),
@@ -28,8 +27,6 @@ export default function ExperiencePage() {
       } else {
         setIsScrolled(false);
       }
-      
-      lastScrollY.current = currentScrollY;
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
@@ -63,8 +60,12 @@ export default function ExperiencePage() {
   return (
     <main className="px-6 md:px-12 lg:px-24 py-16">
       <div className="mx-auto max-w-7xl space-y-12">
-        <section className="grid gap-8 md:gap-12 lg:grid-cols-[0.9fr,1.1fr] items-start">
-          <div className={`space-y-6 lg:sticky lg:top-24 transition-opacity duration-300 ${isScrolled ? 'lg:opacity-0 lg:pointer-events-none' : 'lg:opacity-100'}`}>
+        <section className="grid gap-8 md:gap-12 lg:grid-cols-[0.8fr,1.2fr] items-start">
+          <div
+            className={`space-y-6 lg:sticky lg:top-24 transition-all duration-300 ${
+              isScrolled ? 'lg:opacity-0 lg:-translate-y-4 lg:pointer-events-none' : 'lg:opacity-100'
+            }`}
+          >
             <p className="text-sm uppercase tracking-widest text-[var(--color-muted)]">
               XP
             </p>
@@ -78,39 +79,16 @@ export default function ExperiencePage() {
             </p>
 
             <div className="flex flex-wrap gap-3">
-              <Link href="/cv">
+              <a href={siteUrl('/cv')}>
                 <Button as="span" className="bg-[var(--color-accent)] text-[var(--color-accent-foreground)]">
                   Open CV
                 </Button>
-              </Link>
-              <Link href="/credentials">
+              </a>
+              <a href={siteUrl('/credentials')}>
                 <Button as="span" variant="flat">
                   View Credentials
                 </Button>
-              </Link>
-            </div>
-
-            <Card className="p-5 border border-[var(--color-border)] bg-[var(--color-card)]">
-              <p className="text-sm uppercase tracking-widest text-[var(--color-muted)] mb-3">
-                Positioning
-              </p>
-              <p className="text-lg font-medium leading-relaxed">
-                {profilePositioning.title}
-              </p>
-              <p className="mt-3 text-sm leading-relaxed text-[var(--color-muted-foreground)]">
-                {profilePositioning.summary}
-              </p>
-            </Card>
-
-            <div className="grid grid-cols-2 gap-3 sm:gap-4">
-              <Card className="p-4 border border-[var(--color-border)] bg-[var(--color-card)]">
-                <p className="text-2xl font-semibold">{experienceTimeline.length}</p>
-                <p className="text-sm text-[var(--color-muted-foreground)]">career entries</p>
-              </Card>
-              <Card className="p-4 border border-[var(--color-border)] bg-[var(--color-card)]">
-                <p className="text-2xl font-semibold">1</p>
-                <p className="text-sm text-[var(--color-muted-foreground)]">current role</p>
-              </Card>
+              </a>
             </div>
           </div>
 
@@ -163,9 +141,9 @@ export default function ExperiencePage() {
                           </div>
                         </div>
                         {entry.href && (
-                          <Link href={entry.href} className="inline-flex items-center gap-2 text-sm font-medium text-[var(--color-accent)]">
+                          <a href={siteUrl(entry.href)} className="inline-flex items-center gap-2 text-sm font-medium text-[var(--color-accent)]">
                             View page <ArrowRight className="h-4 w-4" />
-                          </Link>
+                          </a>
                         )}
                       </div>
 
@@ -209,34 +187,6 @@ export default function ExperiencePage() {
           </div>
         </section>
 
-        <section className="grid gap-4 sm:gap-6 sm:grid-cols-2 md:grid-cols-3">
-          <Card className="p-6 border border-[var(--color-border)] bg-[var(--color-card)]">
-            <p className="text-sm uppercase tracking-widest text-[var(--color-muted)] mb-3">
-              What this page shows
-            </p>
-            <p className="text-sm leading-relaxed text-[var(--color-muted-foreground)]">
-              The page follows the actual order of your career, with Sky leading because it is the
-              strongest proof of the platform engineering story.
-            </p>
-          </Card>
-          <Card className="p-6 border border-[var(--color-border)] bg-[var(--color-card)]">
-            <p className="text-sm uppercase tracking-widest text-[var(--color-muted)] mb-3">
-              Use cases
-            </p>
-            <p className="text-sm leading-relaxed text-[var(--color-muted-foreground)]">
-              Share this page when you want something more engaging than a CV but more specific
-              than a homepage.
-            </p>
-          </Card>
-          <Card className="p-6 border border-[var(--color-border)] bg-[var(--color-card)]">
-            <p className="text-sm uppercase tracking-widest text-[var(--color-muted)] mb-3">
-              Next step
-            </p>
-            <p className="text-sm leading-relaxed text-[var(--color-muted-foreground)]">
-              Use the CV page when someone wants the same story in a simple printable format.
-            </p>
-          </Card>
-        </section>
       </div>
     </main>
   );

--- a/services/website/app/page.tsx
+++ b/services/website/app/page.tsx
@@ -2,11 +2,11 @@
 'use client';
 import { allProjects, allPosts } from 'content-collections';
 import { ProjectCard } from './components/ProjectCard';
-import Link from 'next/link';
 import { Button } from '@heroui/react';
 import { BlogCard } from './components/BlogCard';
 import ContactForm from './components/ContactForm';
 import Image from 'next/image';
+import { siteUrl } from './data/site';
 
 const projects = allProjects ?? [];
 const posts = allPosts?.filter((p) => p.thumb) ?? [];
@@ -48,28 +48,28 @@ export default function App() {
                 Get in touch
               </Button>
             </a>
-            <Link href="/projects">
+            <a href={siteUrl('/projects')}>
               <Button 
-                as="span" 
+                as="span"
                 variant="ghost"
                 className="border border-[var(--color-border)] text-[var(--color-foreground)] font-medium px-8 py-3 rounded-lg hover:bg-[var(--color-card)] transition-colors"
               >
                 View Projects
               </Button>
-            </Link>
+            </a>
           </div>
 
           <div className="mt-8 flex flex-wrap items-center gap-3 text-sm text-[var(--color-muted-foreground)]">
             <span className="uppercase tracking-widest text-[var(--color-muted)]">More</span>
-            <Link href="/experience" className="hover:text-[var(--color-accent)] transition-colors">
+            <a href={siteUrl('/experience')} className="hover:text-[var(--color-accent)] transition-colors">
               Experience
-            </Link>
-            <Link href="/credentials" className="hover:text-[var(--color-accent)] transition-colors">
+            </a>
+            <a href={siteUrl('/credentials')} className="hover:text-[var(--color-accent)] transition-colors">
               Credentials
-            </Link>
-            <Link href="/cv" className="hover:text-[var(--color-accent)] transition-colors">
+            </a>
+            <a href={siteUrl('/cv')} className="hover:text-[var(--color-accent)] transition-colors">
               CV
-            </Link>
+            </a>
           </div>
         </div>
       </section>
@@ -141,7 +141,7 @@ export default function App() {
           </div>
           
           <div className="mt-16 text-center">
-            <Link href="/projects">
+            <a href={siteUrl('/projects')}>
               <Button 
                 as="span" 
                 variant="ghost"
@@ -149,7 +149,7 @@ export default function App() {
               >
                 View All Projects
               </Button>
-            </Link>
+            </a>
           </div>
         </div>
       </section>
@@ -181,7 +181,7 @@ export default function App() {
           </div>
           
           <div className="mt-16 text-center">
-            <Link href="/blog">
+            <a href={siteUrl('/blog')}>
               <Button 
                 as="span" 
                 variant="ghost"
@@ -189,7 +189,7 @@ export default function App() {
               >
                 Read All Writing
               </Button>
-            </Link>
+            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
This PR fixes the deployed navbar links by switching the main internal navigation surfaces to plain absolute URLs, which avoids the static-export `index.txt` navigation issue.

It also simplifies the XP page by removing the extra positioning/stats/explanation cards and keeping the intro + scroll-driven timeline focused on the actual career story.

Checks:
- `npm run lint`
- `npm run test -- --runInBand`
- `npm run build`