### PR TITLE
Clean Dependabot config and add CI caches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directory: '/' # Monitor root-level package.json
-    schedule:
-      interval: 'weekly' # Check for updates weekly
-  - package-ecosystem: 'npm'
-    directory: '/apps/nextjs-app' # Monitor dependencies for the Next.js app
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'npm'
-    directory: '/apps/vue-nuxt-app' # Monitor dependencies for the Vue/Nuxt app
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'npm'
-    directory: '/apps/sveltekit-app' # Monitor dependencies for the SvelteKit app
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'npm'
-    directory: '/apps/react-standalone' # Monitor dependencies for the React standalone app
+    directory: '/'
     schedule:
       interval: 'weekly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,15 @@ jobs:
           node-version-file: '.nvmrc'
           check-latest: true
           cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: services/website/.next/cache
+          key: ${{ runner.os }}-next-cache-${{ hashFiles('package-lock.json', 'services/website/app/**/*', 'services/website/content/**/*', 'services/website/public/**/*', 'services/website/.storybook/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-cache-
 
       - name: Upgrade npm
         run: npm install -g npm@11
@@ -60,6 +69,14 @@ jobs:
 
       - name: Build static website
         run: npm run build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-chromium-
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/on-tag-push.yml
+++ b/.github/workflows/on-tag-push.yml
@@ -42,6 +42,15 @@ jobs:
           node-version-file: '.nvmrc'
           check-latest: true
           cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: services/website/.next/cache
+          key: ${{ runner.os }}-next-cache-${{ hashFiles('package-lock.json', 'services/website/app/**/*', 'services/website/content/**/*', 'services/website/public/**/*', 'services/website/.storybook/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-cache-
 
       - name: Upgrade npm
         run: npm install -g npm@11


### PR DESCRIPTION
Cleans up the stale Dependabot config and adds a couple of caches that should help the new CI/e2e foundation run faster.

What changed:
- removed dead Dependabot directories for deleted app-era paths
- kept the root npm update source only
- cached Next.js build artifacts in CI and the tag deploy workflow
- cached Playwright browser binaries in PR CI
- made npm cache usage explicit with the root lockfile

Validation:
- `git diff --check`